### PR TITLE
Add RPM to Openfire nightlies

### DIFF
--- a/src/web/downloads/nightly_openfire.jsp
+++ b/src/web/downloads/nightly_openfire.jsp
@@ -1,17 +1,19 @@
-<%@ page import="java.text.DecimalFormat,
-                 java.io.File,
-                 java.util.Arrays,
-                 java.util.Comparator,
+<%@ page import="java.io.File,
                  java.io.FileFilter,
-                 java.util.Date,
-                 java.text.DateFormat,
-                 java.text.SimpleDateFormat" %>
+                 java.text.DecimalFormat,
+                 java.time.LocalDate,
+                 java.time.format.DateTimeFormatter" %>
+<%@ page import="java.util.*" %>
+<%@ page import="java.util.function.Function" %>
+<%@ page import="java.util.regex.Matcher" %>
+<%@ page import="java.util.regex.Pattern" %>
+<%@ page import="java.util.stream.Collectors" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
 
 
 <%!
-    private static class FileComparator implements Comparator {
+    private static class FileComparator implements Comparator<File> {
         private String clean(String in) {
             int pos = in.indexOf("src_");
             if (pos > -1) {
@@ -19,9 +21,9 @@
             }
             return in;
         }
-        public int compare(Object o1, Object o2) {
-            String s1 = ((File)o1).getName();
-            String s2 = ((File)o2).getName();
+        public int compare(File o1, File o2) {
+            String s1 = o1.getName();
+            String s2 = o2.getName();
             return -clean(s1).compareTo(clean(s2));
         }
     }
@@ -29,12 +31,10 @@
 
 <%
     DecimalFormat mbFormat = new DecimalFormat("#0.00");
-    DateFormat dateFormat = new SimpleDateFormat("MMMM dd, yyyy");
 
     String buildsPath = (String)application.getInitParameter("builds-path");
     String path = null;
     File buildDir = null;
-    File[] files = null;
 %>
 
 <html>
@@ -108,44 +108,92 @@
     // Binaries
     path = buildsPath + "/openfire/dailybuilds/";
     buildDir = new File(path);
-    files = buildDir.listFiles(new FileFilter() {
-        public boolean accept(File pathname) {
-            return pathname.getName().indexOf("_src") == -1;
+    File[] allFiles = buildDir.listFiles( new FileFilter()
+    {
+        @Override
+        public boolean accept( File pathname )
+        {
+            return !pathname.getName().contains( "_src" );
         }
-    });
-    if (files != null && files.length > 0) {
-        Arrays.sort(files, new FileComparator());
-        boolean odd = false;
-        for (int i=0; i < (files.length / 3); i++) {
-            File file1 = files[3 * i];
-            File file2 = files[3 * i + 1];
-            File file3 = files[3 * i + 2];
+    } );
+    boolean odd = false;
+    if (allFiles != null)
+    {
+        // Group and sort by date (as denoted in the filename).
+        final Pattern datePattern = Pattern.compile( "([0-9]{4}-[0-9]{1,2}-[0-9]{1,2})");
+        final SortedMap<String, List<File>> filesByDate = new TreeMap<>( Collections.reverseOrder() );
+        filesByDate.putAll(
+            Arrays.stream( allFiles )
+                .sorted( new FileComparator() )
+                .collect( Collectors.groupingBy( new Function<File, String>()
+                {
+                    @Override
+                    public String apply( File file )
+                    {
+                        final Matcher matcher = datePattern.matcher( file.getName() );
+                        if ( matcher.find() )
+                        {
+                            return matcher.group( 1 );
+                        }
+                        else
+                        {
+                            return "unknown date";
+                        }
+                    }
+            } ) )
+        );
+
+        // Print all date-entries.
+        for ( Map.Entry<String, List<File>> entry : filesByDate.entrySet() )
+        {
+            final String date = entry.getKey();
+            final List<File> files = entry.getValue();
+            files.sort( new FileComparator() );
+
             odd = !odd;
 
     %>
                 <div class="<%= (odd ? "ignite_download_item_odd" : "ignite_download_item_even") %>">
-                    <span class="ignite_download_item_details">
-                        <img src="../images/icon_debian.gif" alt="" width="17" height="16" border="0">
-                        <a href="http://download.igniterealtime.org/openfire/dailybuilds/<%= file3.getName() %>"><%= file3.getName() %></a><br>
-                        <img src="../images/icon_zip.gif" alt="" width="17" height="16" border="0">
-                        <a href="http://download.igniterealtime.org/openfire/dailybuilds/<%= file2.getName() %>"><%= file2.getName() %></a><br>
-                        <img src="../images/icon_zip.gif" alt="" width="17" height="16" border="0">
-                        <a href="http://download.igniterealtime.org/openfire/dailybuilds/<%= file1.getName() %>"><%= file1.getName() %></a>
-                    </span>
-                    <span class="ignite_download_item_date">
-                        <%= dateFormat.format(new Date(file1.lastModified())) %>
-                    </span>
-                    <span class="ignite_download_item_size">
-                        <%= mbFormat.format(file1.length()/(1024.0*1024.0)) %> MB<br>
-                        <%= mbFormat.format(file2.length()/(1024.0*1024.0)) %> MB<br>
-                        <%= mbFormat.format(file3.length()/(1024.0*1024.0)) %> MB
-                    </span>
+                    <table border="0" width="100%">
+    <%
+            final String formattedDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy-MM-dd" ) ).format( DateTimeFormatter.ofPattern( "MMMM dd, yyyy" ) );
+            boolean isFirst = true;
+            for ( final File file : files )
+            {
+                String icon = "../images/icon_zip.gif";
+                if ( file.getName().toLowerCase().endsWith( ".deb" ) )
+                {
+                    icon = "../images/icon_debian.gif";
+                }
+                if ( file.getName().toLowerCase().endsWith( ".rpm" ) )
+                {
+                    icon = "../images/icon_linux.gif";
+                }
+                if ( file.getName().toLowerCase().endsWith( ".exe" ) )
+                {
+                    icon = "../images/icon_win.gif";
+                }
+    %>
+                        <tr>
+                            <td width="1%"><img src="<%= icon %>" alt="" width="17" height="16" border="0"></td>
+                            <td>
+                                <a href="http://download.igniterealtime.org/openfire/dailybuilds/<%= file.getName() %>"><%= file.getName() %></a></td>
+                            <% if ( isFirst ) {
+                                isFirst = false;
+                            %>
+                            <td rowspan="<%= files.size() %>"><%= formattedDate %></td>
+                            <% } %>
+                            <td style="text-align:right;"><%= mbFormat.format(file.length()/(1024.0*1024.0)) %> MB</td>
+                        </tr>
+    <%
+            }
+    %>
+                    </table>
                 </div>
-
-
-    <%  } %>
-
-<%  } %>
+    <%
+        }
+    }
+    %>
 
                 <br>
                 </div>


### PR DESCRIPTION
This commit attempts to list all Openfire nightly builds on the website. Instead of sorting the files by modification date, the date as denoted in the filename is now used.