### PR TITLE
Refreshes cached plugin info periodically.

### DIFF
--- a/src/main/java/org/jivesoftware/site/OpenfireVersionChecker.java
+++ b/src/main/java/org/jivesoftware/site/OpenfireVersionChecker.java
@@ -61,6 +61,11 @@ public class OpenfireVersionChecker {
      */
     private static long lastPluginDate;
 
+    /**
+     * Keeps track of the last time the pluginsInfo data was refreshed.
+     */
+    private static long lastRefresh;
+
 
     /**
      * Verifies if there is a newer version of the Openfire server. The request is specified
@@ -276,10 +281,11 @@ public class OpenfireVersionChecker {
         for (File file : plugins) {
             latestPlugin = latestPlugin < file.lastModified() ? file.lastModified() : latestPlugin;
         }
-        // Update cache of plugins versions (if first time or a plugin has been updated)
-        if (pluginsInfo == null || latestPlugin > lastPluginDate) {
+        // Update cache of plugins versions (if first time or a plugin has been updated, or cache contains old data)
+        if (pluginsInfo == null || latestPlugin > lastPluginDate || lastRefresh + (1000*60*60*24) < System.currentTimeMillis()) {
             pluginsInfo = new ConcurrentHashMap<String, Document>();
             lastPluginDate = latestPlugin;
+            lastRefresh = System.currentTimeMillis();
             for (File file : plugins) {
                 String x1 = new String(getPluginFile(file, "plugin.xml"));
                 Document doc1 = (new SAXReader()).read(new ByteArrayInputStream(x1.getBytes()));


### PR DESCRIPTION
Earlier today, instances of Openfire showed only a partial list of available plugins. It turned out that the webservice did not provide the full list. A restart of Tomcat resolved the problem.

I'm unsure if this actually helps to automatically recover from this issue, but refreshing the cache once a day should not hurt.