### PR TITLE
Disable forumactivity showing old entries

### DIFF
--- a/src/main/webapp/includes/sidebar_projectside.jsp
+++ b/src/main/webapp/includes/sidebar_projectside.jsp
@@ -45,9 +45,11 @@
                 <jsp:param name="project" value="<%= project %>"/>
             </jsp:include>
 
+			<!--
             <jsp:include page="/includes/sidebar_forumactivity.jsp">
                 <jsp:param name="forumID" value="<%= forumID %>"/>
             </jsp:include>
+			-->
             
             <%--
             <jsp:include page="/includes/sidebar_issues.jsp">


### PR DESCRIPTION
The 'forumactivity' sidebar show entries from the old forum. Let's
disable it until it shows entries from the current forum.

Please not that this is untested.