### PR TITLE
slf4j to 1.8.0-beta2 (CVE-2018-8088)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,12 +201,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.8.0-beta2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.25</version>
+            <version>1.8.0-beta2</version>
         </dependency>
         <dependency>
             <groupId>net.sf.json-lib</groupId>


### PR DESCRIPTION
slf4j to 1.8.0-beta2 (CVE-2018-8088)
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8088