### PR TITLE
Fix for 'reply count' of blog posts.

### DIFF
--- a/src/main/java/org/jivesoftware/site/FeedItem.java
+++ b/src/main/java/org/jivesoftware/site/FeedItem.java
@@ -25,7 +25,7 @@ public class FeedItem extends SummaryFeedItem
         contents = firstPost.getString( "cooked" );
         publishedDate = javax.xml.bind.DatatypeConverter.parseDateTime( firstPost.getString( "created_at" ) ).getTime();
         tags = ((List<String>) entry.getJSONArray( "tags" )).toArray( new String[0] );
-        replyCount = entry.getInt( "reply_count" );
+        replyCount = entry.getInt( "posts_count" );
     }
 
 //    public FeedItem( SyndEntry entry )


### PR DESCRIPTION
Up until now, an incorrect attribute was used. The new attribute shows
the number of replies to the blog post.

This fixes https://github.com/igniterealtime/IgniteRealtime-Website/issues/119