### PR TITLE
WEB-85: Convert old-style version numbers in to Openfire compatible ones

### DIFF
--- a/src/main/java/org/jivesoftware/site/OpenfireVersionChecker.java
+++ b/src/main/java/org/jivesoftware/site/OpenfireVersionChecker.java
@@ -183,7 +183,7 @@ public class OpenfireVersionChecker {
             latestPlugin.addAttribute("icon", plugin.getIconURL() );
             latestPlugin.addAttribute("readme", plugin.getReadmeURL() );
             latestPlugin.addAttribute("changelog", plugin.getChangelogURL() );
-            latestPlugin.addAttribute("latest", plugin.getPluginVersion() );
+            latestPlugin.addAttribute("latest", plugin.getPluginVersion().replace("-Release-", ".") );
             latestPlugin.addAttribute("licenseType", plugin.getLicenceType() );
             latestPlugin.addAttribute("author", plugin.getAuthor() );
             latestPlugin.addAttribute("minServerVersion", plugin.getMinimumRequiredOpenfireVersion() );


### PR DESCRIPTION
NB. Not sure The Candy plugin is still valid/useful, but this will at least now show the correct version on the available plugins for the "1.2.3-Release-4" style versioning (by converting it to a straight "1.2.3.4")