### PR TITLE
bypass download-landing.jsp and go direct to downloadServlet

### DIFF
--- a/src/main/java/org/jivesoftware/site/OpenfireVersionChecker.java
+++ b/src/main/java/org/jivesoftware/site/OpenfireVersionChecker.java
@@ -39,7 +39,6 @@ public class OpenfireVersionChecker {
     private static final Logger Log = LoggerFactory.getLogger( OpenfireVersionChecker.class );
 
     protected static DocumentFactory docFactory = DocumentFactory.getInstance();
-    //private static String OPENFIRE_PATH = "https://igniterealtime.org/downloads/download-landing.jsp?file=builds/openfire/";
     private static String OPENFIRE_PATH = "https://igniterealtime.org/downloads/";
     private static String OPENFIRE_LOG = "https://igniterealtime.org/builds/openfire/docs/latest/changelog.html";
     private static final DateFormat RELEASE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");

--- a/src/main/webapp/includes/download-box-openfire-beta.jspf
+++ b/src/main/webapp/includes/download-box-openfire-beta.jspf
@@ -68,7 +68,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= winInstaller.getName() %>"><%= winInstaller.getName() %></a> 32-bit, No Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= winInstaller.getName() %>"><%= winInstaller.getName() %></a> 32-bit, No Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)winInstaller.length()/1024.0/1024.0) %> MB</span>
@@ -76,7 +76,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= winInstaller64.getName() %>"><%= winInstaller64.getName() %></a> 64-bit, No Java JRE <b>(recommended)</b>
+                            <a href="/downloadServlet?filename=openfire/<%= winInstaller64.getName() %>"><%= winInstaller64.getName() %></a> 64-bit, No Java JRE <b>(recommended)</b>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)winInstaller64.length()/1024.0/1024.0) %> MB</span>
@@ -84,7 +84,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= winInstaller_jre.getName() %>"><%= winInstaller_jre.getName() %></a> 32-bit, Includes 32-bit Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= winInstaller_jre.getName() %>"><%= winInstaller_jre.getName() %></a> 32-bit, Includes 32-bit Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)winInstaller_jre.length()/1024.0/1024.0) %> MB</span>
@@ -92,7 +92,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= winInstaller_jre64.getName() %>"><%= winInstaller_jre64.getName() %></a> 64-bit, Includes 64-bit Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= winInstaller_jre64.getName() %>"><%= winInstaller_jre64.getName() %></a> 64-bit, Includes 64-bit Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)winInstaller_jre64.length()/1024.0/1024.0) %> MB</span>
@@ -100,7 +100,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= zip.getName() %>"><%= zip.getName() %></a> Does not include Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= zip.getName() %>"><%= zip.getName() %></a> Does not include Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)zip.length()/1024.0/1024.0) %> MB</span>
@@ -115,7 +115,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_linux.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= rpmnoarch.getName() %>"><%= rpmnoarch.getName() %></a> No JRE Bundled (noarch) <b>(recommended)</b>
+                            <a href="/downloadServlet?filename=openfire/<%= rpmnoarch.getName() %>"><%= rpmnoarch.getName() %></a> No JRE Bundled (noarch) <b>(recommended)</b>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)rpmnoarch.length()/1024.0/1024.0) %> MB</span>
@@ -123,7 +123,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_linux.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= rpm32.getName() %>"><%= rpm32.getName() %></a> Includes Java 32 bit JRE
+                            <a href="/downloadServlet?filename=openfire/<%= rpm32.getName() %>"><%= rpm32.getName() %></a> Includes Java 32 bit JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)rpm32.length()/1024.0/1024.0) %> MB</span>
@@ -131,7 +131,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_linux.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= rpm64.getName() %>"><%= rpm64.getName() %></a> Includes Java 64 bit JRE
+                            <a href="/downloadServlet?filename=openfire/<%= rpm64.getName() %>"><%= rpm64.getName() %></a> Includes Java 64 bit JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)rpm64.length()/1024.0/1024.0) %> MB</span>
@@ -140,7 +140,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_debian.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= debian.getName() %>"><%= debian.getName() %></a> Debian package, no Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= debian.getName() %>"><%= debian.getName() %></a> Debian package, no Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)debian.length()/1024.0/1024.0) %> MB</span>
@@ -150,7 +150,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_solaris.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= solaris.getName() %>"><%= solaris.getName() %></a> Solaris package, no Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= solaris.getName() %>"><%= solaris.getName() %></a> Solaris package, no Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)solaris.length()/1024.0/1024.0) %> MB</span>
@@ -159,7 +159,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a> No Java JRE, works on most Unix variants
+                            <a href="/downloadServlet?filename=openfire/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a> No Java JRE, works on most Unix variants
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binTarGz.length()/1024.0/1024.0) %> MB</span>
@@ -174,7 +174,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_macosx.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= dmg.getName() %>"><%= dmg.getName() %></a>
+                            <a href="/downloadServlet?filename=openfire/<%= dmg.getName() %>"><%= dmg.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)dmg.length()/1024.0/1024.0) %> MB</span>

--- a/src/main/webapp/includes/download-box-openfire.jspf
+++ b/src/main/webapp/includes/download-box-openfire.jspf
@@ -69,7 +69,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= winInstaller.getName() %>"><%= winInstaller.getName() %></a> 32-bit, No Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= winInstaller.getName() %>"><%= winInstaller.getName() %></a> 32-bit, No Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)winInstaller.length()/1024.0/1024.0) %> MB</span>
@@ -77,7 +77,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= winInstaller64.getName() %>"><%= winInstaller64.getName() %></a> 64-bit, No Java JRE <b>(recommended)</b>
+                            <a href="/downloadServlet?filename=openfire/<%= winInstaller64.getName() %>"><%= winInstaller64.getName() %></a> 64-bit, No Java JRE <b>(recommended)</b>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)winInstaller64.length()/1024.0/1024.0) %> MB</span>
@@ -85,7 +85,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= winInstaller_jre.getName() %>"><%= winInstaller_jre.getName() %></a> 32-bit, Includes 32-bit Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= winInstaller_jre.getName() %>"><%= winInstaller_jre.getName() %></a> 32-bit, Includes 32-bit Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)winInstaller_jre.length()/1024.0/1024.0) %> MB</span>
@@ -93,7 +93,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= winInstaller_jre64.getName() %>"><%= winInstaller_jre64.getName() %></a> 64-bit, Includes 64-bit Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= winInstaller_jre64.getName() %>"><%= winInstaller_jre64.getName() %></a> 64-bit, Includes 64-bit Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)winInstaller_jre64.length()/1024.0/1024.0) %> MB</span>
@@ -101,7 +101,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= zip.getName() %>"><%= zip.getName() %></a> Does not include Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= zip.getName() %>"><%= zip.getName() %></a> Does not include Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)zip.length()/1024.0/1024.0) %> MB</span>
@@ -117,7 +117,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_linux.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= rpmnoarch.getName() %>"><%= rpmnoarch.getName() %></a> RPM (no JRE bundled) for Red Hat Linux and variants
+                            <a href="/downloadServlet?filename=openfire/<%= rpmnoarch.getName() %>"><%= rpmnoarch.getName() %></a> RPM (no JRE bundled) for Red Hat Linux and variants
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)rpmnoarch.length()/1024.0/1024.0) %> MB</span>
@@ -127,7 +127,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_linux.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= rpm32.getName() %>"><%= rpm32.getName() %></a> RPM (32bit JRE bundled) for Red Hat Linux and variants
+                            <a href="/downloadServlet?filename=openfire/<%= rpm32.getName() %>"><%= rpm32.getName() %></a> RPM (32bit JRE bundled) for Red Hat Linux and variants
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)rpm32.length()/1024.0/1024.0) %> MB</span>
@@ -137,7 +137,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_linux.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= rpm64.getName() %>"><%= rpm64.getName() %></a> RPM (64bit JRE bundled) for Red Hat Linux and variants
+                            <a href="/downloadServlet?filename=openfire/<%= rpm64.getName() %>"><%= rpm64.getName() %></a> RPM (64bit JRE bundled) for Red Hat Linux and variants
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)rpm64.length()/1024.0/1024.0) %> MB</span>
@@ -147,7 +147,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_debian.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= debian.getName() %>"><%= debian.getName() %></a> Debian package, no Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= debian.getName() %>"><%= debian.getName() %></a> Debian package, no Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)debian.length()/1024.0/1024.0) %> MB</span>
@@ -157,7 +157,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_solaris.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= solaris.getName() %>"><%= solaris.getName() %></a> Solaris package, no Java JRE
+                            <a href="/downloadServlet?filename=openfire/<%= solaris.getName() %>"><%= solaris.getName() %></a> Solaris package, no Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)solaris.length()/1024.0/1024.0) %> MB</span>
@@ -166,7 +166,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a> Works on most Unix variants, no Java JRE 
+                            <a href="/downloadServlet?filename=openfire/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a> Works on most Unix variants, no Java JRE 
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binTarGz.length()/1024.0/1024.0) %> MB</span>
@@ -181,7 +181,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_macosx.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=openfire/<%= dmg.getName() %>"><%= dmg.getName() %></a>
+                            <a href="/downloadServlet?filename=openfire/<%= dmg.getName() %>"><%= dmg.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)dmg.length()/1024.0/1024.0) %> MB</span>

--- a/src/main/webapp/includes/download-box-smack-beta.jspf
+++ b/src/main/webapp/includes/download-box-smack-beta.jspf
@@ -53,7 +53,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=smack/<%= binZip.getName() %>"><%= binZip.getName() %></a> (Binary zip)
+                            <a href="/downloadServlet?filename=smack/<%= binZip.getName() %>"><%= binZip.getName() %></a> (Binary zip)
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binZip.length()/1024.0/1024.0) %> MB</span>
@@ -61,7 +61,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=smack/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a> (Binary tar.gz)
+                            <a href="/downloadServlet?filename=smack/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a> (Binary tar.gz)
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binTarGz.length()/1024.0/1024.0) %> MB</span>
@@ -69,7 +69,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=smack/<%= srcZip.getName() %>"><%= srcZip.getName() %></a> (Source zip)
+                            <a href="/downloadServlet?filename=smack/<%= srcZip.getName() %>"><%= srcZip.getName() %></a> (Source zip)
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)srcZip.length()/1024.0/1024.0) %> MB</span>
@@ -77,7 +77,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=smack/<%= srcTarGz.getName() %>"><%= srcTarGz.getName() %></a> (Source tar.gz)
+                            <a href="/downloadServlet?filename=smack/<%= srcTarGz.getName() %>"><%= srcTarGz.getName() %></a> (Source tar.gz)
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)srcTarGz.length()/1024.0/1024.0) %> MB</span>

--- a/src/main/webapp/includes/download-box-smack.jspf
+++ b/src/main/webapp/includes/download-box-smack.jspf
@@ -49,7 +49,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=smack/<%= binZip.getName() %>"><%= binZip.getName() %></a>
+                            <a href="/downloadServlet?filename=smack/<%= binZip.getName() %>"><%= binZip.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binZip.length()/1024.0/1024.0) %> MB</span>

--- a/src/main/webapp/includes/download-box-spark-beta.jspf
+++ b/src/main/webapp/includes/download-box-spark-beta.jspf
@@ -58,7 +58,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/beta/<%= binExe.getName() %>"><%= binExe.getName() %></a> Offline installation, includes Java JRE (recommended)
+                            <a href="/downloadServlet?filename=spark/beta/<%= binExe.getName() %>"><%= binExe.getName() %></a> Offline installation, includes Java JRE (recommended)
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binExe.length()/1024.0/1024.0) %> MB</span>
@@ -66,7 +66,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/beta/<%= binExeAlt.getName() %>"><%= binExeAlt.getName() %></a> Online installation, does not include Java JRE
+                            <a href="/downloadServlet?filename=spark/beta/<%= binExeAlt.getName() %>"><%= binExeAlt.getName() %></a> Online installation, does not include Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binExeAlt.length()/1024.0/1024.0) %> MB</span>
@@ -75,7 +75,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/beta/<%= binMsi.getName() %>"><%= binMsi.getName() %></a> MSI package, includes Java JRE
+                            <a href="/downloadServlet?filename=spark/beta/<%= binMsi.getName() %>"><%= binMsi.getName() %></a> MSI package, includes Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binMsi.length()/1024.0/1024.0) %> MB</span>
@@ -85,7 +85,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/beta/<%= binMsiAlt.getName() %>"><%= binMsiAlt.getName() %></a> Online MSI package, does not include Java JRE
+                            <a href="/downloadServlet?filename=spark/beta/<%= binMsiAlt.getName() %>"><%= binMsiAlt.getName() %></a> Online MSI package, does not include Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binMsiAlt.length()/1024.0/1024.0) %> MB</span>
@@ -101,7 +101,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/beta/<%= binTar.getName() %>"><%= binTar.getName() %></a>
+                            <a href="/downloadServlet?filename=spark/beta/<%= binTar.getName() %>"><%= binTar.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binTar.length()/1024.0/1024.0) %> MB</span>
@@ -110,7 +110,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_debian.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/beta/<%= debian.getName() %>"><%= debian.getName() %></a> Debian package, no Java JRE
+                            <a href="/downloadServlet?filename=spark/beta/<%= debian.getName() %>"><%= debian.getName() %></a> Debian package, no Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)debian.length()/1024.0/1024.0) %> MB</span>
@@ -126,7 +126,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_macosx.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/beta/<%= binDmg.getName() %>"><%= binDmg.getName() %></a>
+                            <a href="/downloadServlet?filename=spark/beta/<%= binDmg.getName() %>"><%= binDmg.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binDmg.length()/1024.0/1024.0) %> MB</span>

--- a/src/main/webapp/includes/download-box-spark.jspf
+++ b/src/main/webapp/includes/download-box-spark.jspf
@@ -58,7 +58,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/<%= binExeWithJRE.getName() %>"><%= binExeWithJRE.getName() %></a> Offline installation, includes Java JRE
+                            <a href="/downloadServlet?filename=spark/<%= binExeWithJRE.getName() %>"><%= binExeWithJRE.getName() %></a> Offline installation, includes Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binExeWithJRE.length()/1024.0/1024.0) %> MB</span>
@@ -66,7 +66,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_win.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/<%= binExe.getName() %>"><%= binExe.getName() %></a> Online installation, does not include Java JRE
+                            <a href="/downloadServlet?filename=spark/<%= binExe.getName() %>"><%= binExe.getName() %></a> Online installation, does not include Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binExe.length()/1024.0/1024.0) %> MB</span>
@@ -81,7 +81,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/<%= binTar.getName() %>"><%= binTar.getName() %></a>
+                            <a href="/downloadServlet?filename=spark/<%= binTar.getName() %>"><%= binTar.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binTar.length()/1024.0/1024.0) %> MB</span>
@@ -89,7 +89,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_linux.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/<%= rpm.getName() %>"><%= rpm.getName() %></a> RPM for Red Hat Linux and variants
+                            <a href="/downloadServlet?filename=spark/<%= rpm.getName() %>"><%= rpm.getName() %></a> RPM for Red Hat Linux and variants
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)rpm.length()/1024.0/1024.0) %> MB</span>
@@ -97,7 +97,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_debian.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/<%= debian.getName() %>"><%= debian.getName() %></a> Debian package, no Java JRE
+                            <a href="/downloadServlet?filename=spark/<%= debian.getName() %>"><%= debian.getName() %></a> Debian package, no Java JRE
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)debian.length()/1024.0/1024.0) %> MB</span>
@@ -112,7 +112,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_macosx.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/<%= binDmgWithJRE.getName() %>"><%= binDmgWithJRE.getName() %></a> Requires OSX 10.6.7 or higher (includes Java JRE)
+                            <a href="/downloadServlet?filename=spark/<%= binDmgWithJRE.getName() %>"><%= binDmgWithJRE.getName() %></a> Requires OSX 10.6.7 or higher (includes Java JRE)
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binDmgWithJRE.length()/1024.0/1024.0) %> MB</span>
@@ -122,7 +122,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_macosx.gif" alt="" width="17" height="16" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=spark/<%= binDmg.getName() %>"><%= binDmg.getName() %></a> Requires OSX 10.6.7 or higher
+                            <a href="/downloadServlet?filename=spark/<%= binDmg.getName() %>"><%= binDmg.getName() %></a> Requires OSX 10.6.7 or higher
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binDmg.length()/1024.0/1024.0) %> MB</span>

--- a/src/main/webapp/includes/download-box-sparkweb.jspf
+++ b/src/main/webapp/includes/download-box-sparkweb.jspf
@@ -48,7 +48,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=sparkweb/<%= binZip.getName() %>"><%= binZip.getName() %></a>
+                            <a href="/downloadServlet?filename=sparkweb/<%= binZip.getName() %>"><%= binZip.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binZip.length()/1024.0/1024.0) %> MB</span>
@@ -56,7 +56,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=sparkweb/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a>
+                            <a href="/downloadServlet?filename=sparkweb/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binTarGz.length()/1024.0/1024.0) %> MB</span>

--- a/src/main/webapp/includes/download-box-tinder.jspf
+++ b/src/main/webapp/includes/download-box-tinder.jspf
@@ -53,7 +53,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=tinder/<%= binZip.getName() %>"><%= binZip.getName() %></a>
+                            <a href="/downloadServlet?filename=tinder/<%= binZip.getName() %>"><%= binZip.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binZip.length()/1024.0/1024.0) %> MB</span>
@@ -61,7 +61,7 @@
                     <div class="ignite_download_item_even">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=tinder/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a>
+                            <a href="/downloadServlet?filename=tinder/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binTarGz.length()/1024.0/1024.0) %> MB</span>

--- a/src/main/webapp/includes/download-box-whack.jspf
+++ b/src/main/webapp/includes/download-box-whack.jspf
@@ -45,7 +45,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=whack/<%= binJar.getName() %>"><%= binJar.getName() %></a>
+                            <a href="/downloadServlet?filename=whack/<%= binJar.getName() %>"><%= binJar.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binJar.length()/1024.0/1024.0) %> MB</span>

--- a/src/main/webapp/includes/download-box-xiff-beta.jspf
+++ b/src/main/webapp/includes/download-box-xiff-beta.jspf
@@ -53,7 +53,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=xiff/<%= binZip.getName() %>"><%= binZip.getName() %></a>
+                            <a href="/downloadServlet?filename=xiff/<%= binZip.getName() %>"><%= binZip.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binZip.length()/1024.0/1024.0) %> MB</span>

--- a/src/main/webapp/includes/download-box-xiff.jspf
+++ b/src/main/webapp/includes/download-box-xiff.jspf
@@ -53,7 +53,7 @@
                     <div class="ignite_download_item_odd">
                         <span class="ignite_download_item_details">
                             <img src="<%=request.getContextPath()%>/images/icon_zip.gif" alt="" width="17" height="18" border="0">
-                            <a href="<%= path %>/downloads/download-landing.jsp?file=xiff/<%= binZip.getName() %>"><%= binZip.getName() %></a>
+                            <a href="/downloadServlet?filename=xiff/<%= binZip.getName() %>"><%= binZip.getName() %></a>
                         </span>
                         <span class="ignite_download_item_date"><%= buildDate %></span>
                         <span class="ignite_download_item_size"><%= formatter.format((double)binZip.length()/1024.0/1024.0) %> MB</span>

--- a/src/main/webapp/projects/openfire/connection_manager.jsp
+++ b/src/main/webapp/projects/openfire/connection_manager.jsp
@@ -100,7 +100,7 @@
                         <div class="ignite_download_item_odd">
                             <span class="ignite_download_item_details">
                                 <img src="../../images/icon_zip.gif" alt="" width="17" height="16" border="0">
-                                <a href="<%= path %>/downloads/download-landing.jsp?file=connectionmanager/<%= zip.getName() %>"><%= zip.getName() %></a> - Windows archive file
+                                <a href="/downloadServlet?filename=connectionmanager/<%= zip.getName() %>"><%= zip.getName() %></a> - Windows archive file
                             </span>
                             <span class="ignite_download_item_date">
                                 <%= buildDate %>
@@ -112,7 +112,7 @@
                         <div class="ignite_download_item_even">
                             <span class="ignite_download_item_details">
                                 <img src="../../images/icon_zip.gif" alt="" width="17" height="16" border="0">
-                                <a href="<%= path %>/downloads/download-landing.jsp?file=connectionmanager/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a> - Unix/Linux archive file
+                                <a href="/downloadServlet?filename=connectionmanager/<%= binTarGz.getName() %>"><%= binTarGz.getName() %></a> - Unix/Linux archive file
                             </span>
                             <span class="ignite_download_item_date">
                                 <%= buildDate %>
@@ -130,7 +130,7 @@
                         <div class="ignite_download_item_odd">
                             <span class="ignite_download_item_details">
                                 <img src="../../images/icon_zip.gif" alt="" width="17" height="16" border="0">
-                                <a href="<%= path %>/downloads/download-landing.jsp?file=connectionmanager/<%= srcZip.getName() %>"><%= srcZip.getName() %></a> - Windows archive file
+                                <a href="/downloadServlet?filename=connectionmanager/<%= srcZip.getName() %>"><%= srcZip.getName() %></a> - Windows archive file
                             </span>
                             <span class="ignite_download_item_date">
                                 <%= buildDate %>
@@ -142,7 +142,7 @@
                         <div class="ignite_download_item_even">
                             <span class="ignite_download_item_details">
                                 <img src="../../images/icon_zip.gif" alt="" width="17" height="16" border="0">
-                                <a href="<%= path %>/downloads/download-landing.jsp?file=connectionmanager/<%= srcTarGz.getName() %>"><%= srcTarGz.getName() %></a> - Unix/Linux archive file
+                                <a href="/downloadServlet?filename=connectionmanager/<%= srcTarGz.getName() %>"><%= srcTarGz.getName() %></a> - Unix/Linux archive file
                             </span>
                             <span class="ignite_download_item_date">
                                 <%= buildDate %>


### PR DESCRIPTION
See [forums discussion](https://discourse.igniterealtime.org/t/package-downloads-and-updates/88978/4).  The `download-landing.jsp` page offers no useful functionality.