### PR TITLE
WEB-60 add old versions links

### DIFF
--- a/src/main/webapp/includes/download-box-openfire.jspf
+++ b/src/main/webapp/includes/download-box-openfire.jspf
@@ -46,8 +46,8 @@
         <div class="ignite_downloads_content">
             <span class="ignite_downloads_info">
                 <a href="<%=request.getContextPath()%>/projects/openfire/plugins.jsp"><strong>Plugins</strong></a> |
-                <a href="<%=request.getContextPath()%>/builds/openfire/docs/latest/README.html">Readme</a> |
-                <a href="<%=request.getContextPath()%>/builds/openfire/docs/latest/LICENSE.html">License</a> |
+                <a href="https://github.com/igniterealtime/Openfire/releases"><strong>Old versions</strong></a>
+                <a href="<%=request.getContextPath()%>/builds/openfire/docs/latest/README.html">Readme & License</a> |
                 <a href="<%=request.getContextPath()%>/builds/openfire/docs/latest/changelog.html">Changelog</a> |
                 <a href="nightly_openfire.jsp">Nightly Builds</a> |
                 <a href="https://github.com/igniterealtime/Openfire">Source Code</a>

--- a/src/main/webapp/includes/download-box-openfire.jspf
+++ b/src/main/webapp/includes/download-box-openfire.jspf
@@ -46,7 +46,7 @@
         <div class="ignite_downloads_content">
             <span class="ignite_downloads_info">
                 <a href="<%=request.getContextPath()%>/projects/openfire/plugins.jsp"><strong>Plugins</strong></a> |
-                <a href="https://github.com/igniterealtime/Openfire/releases"><strong>Old versions</strong></a>
+                <a href="https://github.com/igniterealtime/Openfire/releases"><strong>Old versions</strong></a> |
                 <a href="<%=request.getContextPath()%>/builds/openfire/docs/latest/README.html">Readme & License</a> |
                 <a href="<%=request.getContextPath()%>/builds/openfire/docs/latest/changelog.html">Changelog</a> |
                 <a href="nightly_openfire.jsp">Nightly Builds</a> |

--- a/src/main/webapp/includes/download-box-smack.jspf
+++ b/src/main/webapp/includes/download-box-smack.jspf
@@ -30,7 +30,7 @@
 
         <div class="ignite_downloads_content">
             <span class="ignite_downloads_info">
-                <a href="https://github.com/igniterealtime/Smack/releases"><strong>Old versions</strong></a>
+                <a href="https://github.com/igniterealtime/Smack/releases"><strong>Old versions</strong></a> |
                 <a href="<%=request.getContextPath()%>/builds/smack/docs/latest/README.html">Readme & License</a> |
                 <a href="<%=request.getContextPath()%>/builds/smack/docs/latest/changelog.html">Changelog</a> |
                 <a href="nightly_smack.jsp">Nightly Builds</a> |

--- a/src/main/webapp/includes/download-box-smack.jspf
+++ b/src/main/webapp/includes/download-box-smack.jspf
@@ -30,7 +30,7 @@
 
         <div class="ignite_downloads_content">
             <span class="ignite_downloads_info">
-                <a href="https://github.com/igniterealtime/Smack/releases"><strong>Old versions</strong></a> |
+                <!--<a href="https://github.com/igniterealtime/Smack/releases"><strong>Old versions</strong></a> |-->
                 <a href="<%=request.getContextPath()%>/builds/smack/docs/latest/README.html">Readme & License</a> |
                 <a href="<%=request.getContextPath()%>/builds/smack/docs/latest/changelog.html">Changelog</a> |
                 <a href="nightly_smack.jsp">Nightly Builds</a> |

--- a/src/main/webapp/includes/download-box-smack.jspf
+++ b/src/main/webapp/includes/download-box-smack.jspf
@@ -30,7 +30,7 @@
 
         <div class="ignite_downloads_content">
             <span class="ignite_downloads_info">
-                <!-- <a href="#"><strong>Plugins</strong></a> |  -->
+                <a href="https://github.com/igniterealtime/Smack/releases"><strong>Old versions</strong></a>
                 <a href="<%=request.getContextPath()%>/builds/smack/docs/latest/README.html">Readme & License</a> |
                 <a href="<%=request.getContextPath()%>/builds/smack/docs/latest/changelog.html">Changelog</a> |
                 <a href="nightly_smack.jsp">Nightly Builds</a> |

--- a/src/main/webapp/includes/download-box-spark.jspf
+++ b/src/main/webapp/includes/download-box-spark.jspf
@@ -37,6 +37,7 @@
         <div class="ignite_downloads_content">
             <span class="ignite_downloads_info">
                 <!-- <a href="#"><strong>Plugins</strong></a> |  -->
+                <a href="https://github.com/igniterealtime/Spark/releases"><strong>Old versions</strong></a> |
                 <a href="<%=request.getContextPath()%>/builds/spark/docs/latest/README.html">Readme & License</a> |
                 <a href="<%=request.getContextPath()%>/builds/spark/docs/latest/changelog.html">Changelog</a>  |
                 <a href="nightly_spark.jsp">Nightly Builds</a>  |


### PR DESCRIPTION
Menu row for Openfire is getting too long. So i was thinking maybe we can remove separate "Source  Code" links from Downloads page as we already have main Source menu at the top. Or maybe make names shorter, like 'Nightlies" and just "Source" instead, so menu is not overlapping with Openfire x.x.x heading. @akrherz @guusdk 