### PR TITLE
Drop old/duplicate/unused HttpClient 3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,11 +180,6 @@
             <version>1.4</version>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
             <version>2.1.3</version>


### PR DESCRIPTION
HttpClient 4.5.13 is also defined. 3.1 seems to go unused. Let's drop it.