### PR TITLE
Add reference to checksum location on Spark and Openfire download page.

### DIFF
--- a/src/main/webapp/includes/download-box-openfire.jspf
+++ b/src/main/webapp/includes/download-box-openfire.jspf
@@ -57,6 +57,8 @@
             <a href="https://discourse.igniterealtime.org/t/91023">no longer distributed</a>
             with the Openfire release.</p>
 
+            <p>Checksums for Openfire distributables are available in the <a href="https://github.com/igniterealtime/Openfire/releases">Github 'releases' section</a> of the Openfire source code repository.</p>
+
             <span class="ignite_download_choose">Choose your platform:</span>
             <span id="openfireWindowsBtn" class="ignite_download_btn"><a href="#" onClick="toggleDownloadPanel('openfireWindows','openfireLinux', 'openfireMac'); return false;"></a></span>
             <span id="openfireLinuxBtn" class="ignite_download_btn"><a href="#" onClick="toggleDownloadPanel('openfireLinux','openfireWindows', 'openfireMac'); return false;"></a></span>

--- a/src/main/webapp/includes/download-box-spark.jspf
+++ b/src/main/webapp/includes/download-box-spark.jspf
@@ -48,6 +48,8 @@
             <h2>Spark <%= version %></h2>
             <p>Cross-platform real-time collaboration client optimized for business and organizations.</p>
 
+            <p>Checksums for Spark distributables are available in the <a href="https://github.com/igniterealtime/Spark/releases">Github 'releases' section</a> of the Spark source code repository.</p>
+
             <span class="ignite_download_choose">Choose your platform:</span>
             <span id="sparkWindowsBtn" class="ignite_download_btn"><a href="#" onClick="toggleDownloadPanel('sparkWindows','sparkLinux','sparkMac'); return false;"></a></span>
             <span id="sparkLinuxBtn" class="ignite_download_btn"><a href="#" onClick="toggleDownloadPanel('sparkLinux','sparkWindows','sparkMac'); return false;"></a></span>


### PR DESCRIPTION
I've heard about quite some confusion around the checksums not being available. A quick reference to where they can be found would have prevented this.
