### PR TITLE
fixes #208: plugin version identifier comparision

### DIFF
--- a/src/main/java/org/jivesoftware/site/PluginManager.java
+++ b/src/main/java/org/jivesoftware/site/PluginManager.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletConfig;
 
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.dom4j.DocumentException;
+import org.jivesoftware.util.PluginVersionComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,8 +114,7 @@ public class PluginManager
         }
         else
         {
-            // FIXME: don't use alphabetical sorting
-            stream = stream.sorted( Comparator.comparing( (Metadata::getPluginVersion) ).reversed() );
+            stream = stream.sorted( Comparator.comparing( Metadata::getPluginVersion, new PluginVersionComparator() ).reversed() );
         }
 
         if (parsedRequest.snapshotQualifier != null) {
@@ -273,7 +273,7 @@ public class PluginManager
         return unordered.stream()
             .sorted(
                 Comparator.comparing( (PluginManager.Metadata o) -> o.humanReadableName.toLowerCase() )
-                .thenComparing( Comparator.comparing( (PluginManager.Metadata o) -> o.pluginVersion).reversed() ) // TODO don't base version-sorting on alphabet.
+                .thenComparing( Comparator.comparing( (PluginManager.Metadata o) -> o.pluginVersion, new PluginVersionComparator()).reversed() )
                 .thenComparing( Comparator.comparing( (PluginManager.Metadata o) -> o.isRelease ? o.releaseDate : o.snapshotCreationDate ).reversed()  )
             )
             .collect( Collectors.toList() );

--- a/src/main/java/org/jivesoftware/util/PluginVersionComparator.java
+++ b/src/main/java/org/jivesoftware/util/PluginVersionComparator.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.util;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+/**
+ * A Comparator that is intended to be used for version identifiers that do not necessarily 'neatly' fit in the
+ * x.y.z syntax. This should be used as a last resort, as with the unpredictability of the value format that this
+ * comparator uses, the outcome is equally unpredictable.
+ *
+ * This comparator splits each value that is to be compared in segments which are separated by a full stop character,
+ * using a left-zero pad to 25 characters, then reconstructing the value again by merging each section with full stop
+ * characters. The resulting value is alphabetically compared.
+ *
+ * The intention here is to have a poor-mans solution that allows x.y.z formatted strings that use multiple digets per
+ * segment to be correctly sorted, when alphabetic sorting is used.
+ * Examples:
+ * <pre>
+ * 1.8.4  -> 0000000000000000000000001.0000000000000000000000008.0000000000000000000000004
+ * 1.14.4 -> 0000000000000000000000001.0000000000000000000000014.0000000000000000000000004
+ * foobar -> 0000000000000000000foobar
+ * </pre>
+ *
+ * This implementation does not allow null values.
+ */
+public class PluginVersionComparator implements Comparator<String>
+{
+    static final int ZERO_PAD_LENGTH = 25;
+
+    @Override
+    public int compare(final String o1, final String o2)
+    {
+        return zeropad(o1).compareTo(zeropad(o2));
+    }
+
+    static String zeropad(final String value) {
+        return Arrays.stream(value.split("\\."))
+            .map(segment -> StringUtils.zeroPadString(segment, ZERO_PAD_LENGTH))
+            .collect(Collectors.joining("."));
+    }
+}

--- a/src/main/java/org/jivesoftware/util/PluginVersionComparator.java
+++ b/src/main/java/org/jivesoftware/util/PluginVersionComparator.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  * using a left-zero pad to 25 characters, then reconstructing the value again by merging each section with full stop
  * characters. The resulting value is alphabetically compared.
  *
- * The intention here is to have a poor-mans solution that allows x.y.z formatted strings that use multiple digets per
+ * The intention here is to have a "poor man's solution" that allows x.y.z formatted strings that use multiple digits per
  * segment to be correctly sorted, when alphabetic sorting is used.
  * Examples:
  * <pre>

--- a/src/test/java/org/jivesoftware/util/PluginVersionComparatorTest.java
+++ b/src/test/java/org/jivesoftware/util/PluginVersionComparatorTest.java
@@ -1,0 +1,59 @@
+package org.jivesoftware.util;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class PluginVersionComparatorTest
+{
+    @Test
+    public void testString() throws Exception
+    {
+        // Setup test fixture.
+        final String o1 = "bb";
+        final String o2 = "aa";
+        final List<String> collection = Arrays.asList(o1, o2);
+
+        // Execute system under test.
+        collection.sort(new PluginVersionComparator());
+
+        // Verify results.
+        assertEquals(o2, collection.get(0));
+        assertEquals(o1, collection.get(1));
+    }
+
+    @Test
+    public void testXYZ() throws Exception
+    {
+        // Setup test fixture.
+        final String o1 = "0.2.2";
+        final String o2 = "0.1.4";
+        final List<String> collection = Arrays.asList(o1, o2);
+
+        // Execute system under test.
+        collection.sort(new PluginVersionComparator());
+
+        // Verify results.
+        assertEquals(o2, collection.get(0));
+        assertEquals(o1, collection.get(1));
+    }
+
+    @Test
+    public void testMultiDigitXYZ() throws Exception
+    {
+        // Setup test fixture.
+        final String o1 = "10.2.2";
+        final String o2 = "1.1.4";
+        final List<String> collection = Arrays.asList(o1, o2);
+
+        // Execute system under test.
+        collection.sort(new PluginVersionComparator());
+
+        // Verify results.
+        assertEquals(o2, collection.get(0));
+        assertEquals(o1, collection.get(1));
+    }
+}


### PR DESCRIPTION
As the website code has to deal with plugin version identifiers that sometimes predate the stricter Maven syntax, it is using a simple alphabetic comparator. This causes problems when comparing numbers that do not have the same amount of digits (eg 10 < 9).

This commit works around this issue, by zero-padding all values to the same lenght, before applying the alphabetic comparator. This should not affect ordering of the free-format version identifiers to much, while it will ensure that numeric ordering is improved: 10 > 09.