### PR TITLE
Change title of Openfire plugin archive page

### DIFF
--- a/src/main/webapp/projects/openfire/plugin-archive.jsp
+++ b/src/main/webapp/projects/openfire/plugin-archive.jsp
@@ -24,7 +24,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
 <html>
 <head>
-    <title>Openfire Plugins</title>
+    <title>Openfire <%= URLEncoder.encode(pluginName, "utf-8") %> Plugin Archive</title>
     <meta name="body-id" content="projects" />
     <style type="text/css" media="screen">
         @import "../../styles/interior.css";


### PR DESCRIPTION
Third party software uses the title to render the text on a link to this page. It should include the name of the plugin that the page is an archive for, instead of being a generic name.