### PR TITLE
Restoring 'blog' content on project pages

### DIFF
--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,10 +1,8 @@
-<%@ page import="org.jivesoftware.site.Versions" %>
-<%@ page import="org.jivesoftware.webservices.RestClient" %>
-<%@ page import="org.jivesoftware.site.FeedManager" %>
-
+<%@ page import="org.jivesoftware.site.Versions"%>
+<%@ page import="org.jivesoftware.webservices.RestClient"%>
+<%@ page import="org.jivesoftware.site.FeedManager"%>
 <%@ taglib uri="http://www.opensymphony.com/oscache" prefix="cache" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
 <%@ taglib uri="http://igniterealtime.org/website/tags" prefix="ir" %>
 <%
     String baseUrl = config.getServletContext().getInitParameter("discourse_baseurl");
@@ -17,7 +15,6 @@
     request.setAttribute( "feedManager", FeedManager.getInstance() );
     request.setAttribute( "restClient", new RestClient() );
 %>
-
 <html>
 <head>
 <title>a real time collaboration community site</title>
@@ -119,35 +116,13 @@
                     <!-- END blog header -->
 
                     <%-- Show blog feed --%>
-
                     <cache:cache time="600" key="${baseUrl.concat('/c/blogs/ignite-realtime-blogs.rss')}">
                         <c:forEach items="${feedManager.getItems( baseUrl, '/c/blogs/ignite-realtime-blogs.rss', 5 )}" var="item" varStatus="status">
                             <ir:blogpost item="${item}" isOdd="${status.count % 2 != 0}"/>
                         </c:forEach>
                     </cache:cache>
 
-                            <%--<% try { %>--%>
-                <%--<%--%>
-                    <%--RestClient client = new RestClient();--%>
-                    <%--String blogSearchUrl = restBaseUrl + "/search/places?filter=search(Ignite,Realtime,Blog)&filter=type(blog)";--%>
-                    <%--JSONObject result = client.get(blogSearchUrl);--%>
-                    <%--JSONArray results = result.getJSONArray("list");--%>
-                    <%--JSONObject blog = (JSONObject)results.get(0);--%>
-                    <%--String contentsUrl = blog.getJSONObject("resources").getJSONObject("contents").getString("ref");--%>
-
-                    <%--String blogRestUrl = contentsUrl + "?count=5";--%>
-                    <%--result = client.get(blogRestUrl);--%>
-                    <%--JSONArray posts = result.getJSONArray("list");--%>
-                    <%--request.setAttribute("posts", posts);--%>
-                <%--%>--%>
-                    <%--<jsp:include page="/includes/blogposts.jsp" />--%>
-                <%--<% } catch (Exception e) { %>--%>
-                    <%--<cache:usecached />--%>
-                <%--<% } %>--%>
-                    <%--</cache:cache>--%>
                 </div>
-
-                <style type="text/css"></style>
                 <!-- END 'latest blog entries' column -->
             </div>
             <!-- END home page body content area -->

--- a/src/main/webapp/projects/asterisk/index.jsp
+++ b/src/main/webapp/projects/asterisk/index.jsp
@@ -1,8 +1,20 @@
 <%@ page import="org.jivesoftware.site.Versions"%>
-
+<%@ page import="org.jivesoftware.webservices.RestClient"%>
+<%@ page import="org.jivesoftware.site.FeedManager"%>
 <%@ taglib uri="http://www.opensymphony.com/oscache" prefix="cache" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
+<%@ taglib uri="http://igniterealtime.org/website/tags" prefix="ir" %>
+<%
+    String baseUrl = config.getServletContext().getInitParameter("discourse_baseurl");
+    if ( baseUrl == null || baseUrl.isEmpty() )
+    {
+        baseUrl = "https://discourse.igniterealtime.org/";
+    }
+
+    request.setAttribute( "baseUrl", baseUrl );
+    request.setAttribute( "feedManager", FeedManager.getInstance() );
+    request.setAttribute( "restClient", new RestClient() );
+%>
 <html>
 <head>
 <title>Asterisk-IM</title>
@@ -88,8 +100,26 @@ fully supported in the <a href="../spark/">Spark</a> IM client. Read more about 
                 </div>
             </div>
             <!-- END small panel -->
-            
-            
+
+            <!-- BEGIN 'latest blog entries' column -->
+            <div id="ignite_home_body_leftcol">
+                <!-- BEGIN blog header -->
+                <div id="ignite_blog_header">
+                    <span id="ignite_blog_header_label">
+                        Latest <a href="${baseUrl}/tags/c/blogs/ignite-realtime-blogs/5/asterisk">Blog</a> Entries
+                    </span>
+                </div>
+                <!-- END blog header -->
+
+                <%-- Show blog feed --%>
+                <cache:cache time="600" key="${baseUrl.concat('/tags/c/blogs/ignite-realtime-blogs/5/asterisk')}">
+                    <c:forEach items="${feedManager.getTaggedItems( baseUrl, '/c/blogs/ignite-realtime-blogs.rss', 'asterisk', 5 )}" var="item" varStatus="status">
+                        <ir:blogpost item="${item}" isOdd="${status.count % 2 != 0}"/>
+                    </c:forEach>
+                </cache:cache>
+            </div>
+            <!-- END 'latest blog entries' column -->
+
         </div>
         <!-- END left column (main content) -->
         

--- a/src/main/webapp/projects/botz/index.jsp
+++ b/src/main/webapp/projects/botz/index.jsp
@@ -1,8 +1,20 @@
 <%@ page import="org.jivesoftware.site.Versions"%>
-
+<%@ page import="org.jivesoftware.webservices.RestClient"%>
+<%@ page import="org.jivesoftware.site.FeedManager"%>
 <%@ taglib uri="http://www.opensymphony.com/oscache" prefix="cache" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
+<%@ taglib uri="http://igniterealtime.org/website/tags" prefix="ir" %>
+<%
+    String baseUrl = config.getServletContext().getInitParameter("discourse_baseurl");
+    if ( baseUrl == null || baseUrl.isEmpty() )
+    {
+        baseUrl = "https://discourse.igniterealtime.org/";
+    }
+
+    request.setAttribute( "baseUrl", baseUrl );
+    request.setAttribute( "feedManager", FeedManager.getInstance() );
+    request.setAttribute( "restClient", new RestClient() );
+%>
 <html>
 <head>
 <title>Botz</title>
@@ -74,8 +86,26 @@
                 </div>
             </div>
             <!-- END small panel -->
-            
-            
+
+            <!-- BEGIN 'latest blog entries' column -->
+            <div id="ignite_home_body_leftcol">
+                <!-- BEGIN blog header -->
+                <div id="ignite_blog_header">
+                    <span id="ignite_blog_header_label">
+                        Latest <a href="${baseUrl}/tags/c/blogs/ignite-realtime-blogs/5/botz">Blog</a> Entries
+                    </span>
+                </div>
+                <!-- END blog header -->
+
+                <%-- Show blog feed --%>
+                <cache:cache time="600" key="${baseUrl.concat('/tags/c/blogs/ignite-realtime-blogs/5/botz')}">
+                    <c:forEach items="${feedManager.getTaggedItems( baseUrl, '/c/blogs/ignite-realtime-blogs.rss', 'botz', 5 )}" var="item" varStatus="status">
+                        <ir:blogpost item="${item}" isOdd="${status.count % 2 != 0}"/>
+                    </c:forEach>
+                </cache:cache>
+            </div>
+            <!-- END 'latest blog entries' column -->
+
         </div>
         <!-- END left column (main content) -->
         

--- a/src/main/webapp/projects/openfire/index.jsp
+++ b/src/main/webapp/projects/openfire/index.jsp
@@ -1,9 +1,20 @@
 <%@ page import="org.jivesoftware.site.Versions"%>
-
+<%@ page import="org.jivesoftware.webservices.RestClient"%>
+<%@ page import="org.jivesoftware.site.FeedManager"%>
 <%@ taglib uri="http://www.opensymphony.com/oscache" prefix="cache" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
-<%@ taglib tagdir="/WEB-INF/tags" prefix="i" %>
+<%@ taglib uri="http://igniterealtime.org/website/tags" prefix="ir" %>
+<%
+    String baseUrl = config.getServletContext().getInitParameter("discourse_baseurl");
+    if ( baseUrl == null || baseUrl.isEmpty() )
+    {
+        baseUrl = "https://discourse.igniterealtime.org/";
+    }
+
+    request.setAttribute( "baseUrl", baseUrl );
+    request.setAttribute( "feedManager", FeedManager.getInstance() );
+    request.setAttribute( "restClient", new RestClient() );
+%>
 <html>
 <head>
 <title>Openfire Server</title>
@@ -91,8 +102,25 @@
                 </div>
             </div>
             <!-- END small panel -->
-            
-            
+
+            <!-- BEGIN 'latest blog entries' column -->
+            <div id="ignite_home_body_leftcol">
+                <!-- BEGIN blog header -->
+                <div id="ignite_blog_header">
+                    <span id="ignite_blog_header_label">
+                        Latest <a href="${baseUrl}/tags/c/blogs/ignite-realtime-blogs/5/openfire">Blog</a> Entries
+                    </span>
+                </div>
+                <!-- END blog header -->
+
+                <%-- Show blog feed --%>
+                <cache:cache time="600" key="${baseUrl.concat('/tags/c/blogs/ignite-realtime-blogs/5/openfire')}">
+                    <c:forEach items="${feedManager.getTaggedItems( baseUrl, '/c/blogs/ignite-realtime-blogs.rss', 'openfire', 5 )}" var="item" varStatus="status">
+                        <ir:blogpost item="${item}" isOdd="${status.count % 2 != 0}"/>
+                    </c:forEach>
+                </cache:cache>
+            </div>
+            <!-- END 'latest blog entries' column -->
             
         </div>
         <!-- END left column (main content) -->

--- a/src/main/webapp/projects/pade/index.jsp
+++ b/src/main/webapp/projects/pade/index.jsp
@@ -1,8 +1,20 @@
 <%@ page import="org.jivesoftware.site.Versions"%>
-
+<%@ page import="org.jivesoftware.webservices.RestClient"%>
+<%@ page import="org.jivesoftware.site.FeedManager"%>
 <%@ taglib uri="http://www.opensymphony.com/oscache" prefix="cache" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
+<%@ taglib uri="http://igniterealtime.org/website/tags" prefix="ir" %>
+<%
+    String baseUrl = config.getServletContext().getInitParameter("discourse_baseurl");
+    if ( baseUrl == null || baseUrl.isEmpty() )
+    {
+        baseUrl = "https://discourse.igniterealtime.org/";
+    }
+
+    request.setAttribute( "baseUrl", baseUrl );
+    request.setAttribute( "feedManager", FeedManager.getInstance() );
+    request.setAttribute( "restClient", new RestClient() );
+%>
 <html>
 <head>
 <title>Pade</title>
@@ -92,8 +104,26 @@
                 </div>
             </div>
             <!-- END small panel -->
-            
-            
+
+            <!-- BEGIN 'latest blog entries' column -->
+            <div id="ignite_home_body_leftcol">
+                <!-- BEGIN blog header -->
+                <div id="ignite_blog_header">
+                    <span id="ignite_blog_header_label">
+                        Latest <a href="${baseUrl}/tags/c/blogs/ignite-realtime-blogs/5/pade">Blog</a> Entries
+                    </span>
+                </div>
+                <!-- END blog header -->
+
+                <%-- Show blog feed --%>
+                <cache:cache time="600" key="${baseUrl.concat('/tags/c/blogs/ignite-realtime-blogs/5/pade')}">
+                    <c:forEach items="${feedManager.getTaggedItems( baseUrl, '/c/blogs/ignite-realtime-blogs.rss', 'pade', 5 )}" var="item" varStatus="status">
+                        <ir:blogpost item="${item}" isOdd="${status.count % 2 != 0}"/>
+                    </c:forEach>
+                </cache:cache>
+            </div>
+            <!-- END 'latest blog entries' column -->
+
         </div>
         <!-- END left column (main content) -->
         

--- a/src/main/webapp/projects/smack/index.jsp
+++ b/src/main/webapp/projects/smack/index.jsp
@@ -1,8 +1,20 @@
 <%@ page import="org.jivesoftware.site.Versions"%>
-
+<%@ page import="org.jivesoftware.webservices.RestClient"%>
+<%@ page import="org.jivesoftware.site.FeedManager"%>
 <%@ taglib uri="http://www.opensymphony.com/oscache" prefix="cache" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
+<%@ taglib uri="http://igniterealtime.org/website/tags" prefix="ir" %>
+<%
+    String baseUrl = config.getServletContext().getInitParameter("discourse_baseurl");
+    if ( baseUrl == null || baseUrl.isEmpty() )
+    {
+        baseUrl = "https://discourse.igniterealtime.org/";
+    }
+
+    request.setAttribute( "baseUrl", baseUrl );
+    request.setAttribute( "feedManager", FeedManager.getInstance() );
+    request.setAttribute( "restClient", new RestClient() );
+%>
 <html>
 <head>
 <title>Smack API</title>
@@ -90,6 +102,25 @@
                 </div>
             </div>
             <!-- END small panel -->
+
+            <!-- BEGIN 'latest blog entries' column -->
+            <div id="ignite_home_body_leftcol">
+                <!-- BEGIN blog header -->
+                <div id="ignite_blog_header">
+                    <span id="ignite_blog_header_label">
+                        Latest <a href="${baseUrl}/tags/c/blogs/ignite-realtime-blogs/5/smack">Blog</a> Entries
+                    </span>
+                </div>
+                <!-- END blog header -->
+
+                <%-- Show blog feed --%>
+                <cache:cache time="600" key="${baseUrl.concat('/tags/c/blogs/ignite-realtime-blogs/5/smack')}">
+                    <c:forEach items="${feedManager.getTaggedItems( baseUrl, '/c/blogs/ignite-realtime-blogs.rss', 'smack', 5 )}" var="item" varStatus="status">
+                        <ir:blogpost item="${item}" isOdd="${status.count % 2 != 0}"/>
+                    </c:forEach>
+                </cache:cache>
+            </div>
+            <!-- END 'latest blog entries' column -->
 
         </div>
         <!-- END left column (main content) -->

--- a/src/main/webapp/projects/spark/index.jsp
+++ b/src/main/webapp/projects/spark/index.jsp
@@ -1,8 +1,20 @@
 <%@ page import="org.jivesoftware.site.Versions"%>
-
+<%@ page import="org.jivesoftware.webservices.RestClient"%>
+<%@ page import="org.jivesoftware.site.FeedManager"%>
 <%@ taglib uri="http://www.opensymphony.com/oscache" prefix="cache" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
+<%@ taglib uri="http://igniterealtime.org/website/tags" prefix="ir" %>
+<%
+    String baseUrl = config.getServletContext().getInitParameter("discourse_baseurl");
+    if ( baseUrl == null || baseUrl.isEmpty() )
+    {
+        baseUrl = "https://discourse.igniterealtime.org/";
+    }
+
+    request.setAttribute( "baseUrl", baseUrl );
+    request.setAttribute( "feedManager", FeedManager.getInstance() );
+    request.setAttribute( "restClient", new RestClient() );
+%>
 <html>
 <head>
 <title>Spark IM Client</title>
@@ -91,8 +103,26 @@
                 </div>
             </div>
             <!-- END small panel -->
-            
-            
+
+            <!-- BEGIN 'latest blog entries' column -->
+            <div id="ignite_home_body_leftcol">
+                <!-- BEGIN blog header -->
+                <div id="ignite_blog_header">
+                    <span id="ignite_blog_header_label">
+                        Latest <a href="${baseUrl}/tags/c/blogs/ignite-realtime-blogs/5/spark">Blog</a> Entries
+                    </span>
+                </div>
+                <!-- END blog header -->
+
+                <%-- Show blog feed --%>
+                <cache:cache time="600" key="${baseUrl.concat('/tags/c/blogs/ignite-realtime-blogs/5/spark')}">
+                    <c:forEach items="${feedManager.getTaggedItems( baseUrl, '/c/blogs/ignite-realtime-blogs.rss', 'spark', 5 )}" var="item" varStatus="status">
+                        <ir:blogpost item="${item}" isOdd="${status.count % 2 != 0}"/>
+                    </c:forEach>
+                </cache:cache>
+            </div>
+            <!-- END 'latest blog entries' column -->
+
         </div>
         <!-- END left column (main content) -->
         

--- a/src/main/webapp/projects/tinder/index.jsp
+++ b/src/main/webapp/projects/tinder/index.jsp
@@ -1,8 +1,20 @@
 <%@ page import="org.jivesoftware.site.Versions"%>
-
+<%@ page import="org.jivesoftware.webservices.RestClient"%>
+<%@ page import="org.jivesoftware.site.FeedManager"%>
 <%@ taglib uri="http://www.opensymphony.com/oscache" prefix="cache" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
+<%@ taglib uri="http://igniterealtime.org/website/tags" prefix="ir" %>
+<%
+    String baseUrl = config.getServletContext().getInitParameter("discourse_baseurl");
+    if ( baseUrl == null || baseUrl.isEmpty() )
+    {
+        baseUrl = "https://discourse.igniterealtime.org/";
+    }
+
+    request.setAttribute( "baseUrl", baseUrl );
+    request.setAttribute( "feedManager", FeedManager.getInstance() );
+    request.setAttribute( "restClient", new RestClient() );
+%>
 <html>
 <head>
 <title>Tinder API</title>
@@ -89,8 +101,26 @@
                 </div>
             </div>
             <!-- END small panel -->
-            
-            
+
+            <!-- BEGIN 'latest blog entries' column -->
+            <div id="ignite_home_body_leftcol">
+                <!-- BEGIN blog header -->
+                <div id="ignite_blog_header">
+                    <span id="ignite_blog_header_label">
+                        Latest <a href="${baseUrl}/tags/c/blogs/ignite-realtime-blogs/5/tinder">Blog</a> Entries
+                    </span>
+                </div>
+                <!-- END blog header -->
+
+                <%-- Show blog feed --%>
+                <cache:cache time="600" key="${baseUrl.concat('/tags/c/blogs/ignite-realtime-blogs/5/tinder')}">
+                    <c:forEach items="${feedManager.getTaggedItems( baseUrl, '/c/blogs/ignite-realtime-blogs.rss', 'tinder', 5 )}" var="item" varStatus="status">
+                        <ir:blogpost item="${item}" isOdd="${status.count % 2 != 0}"/>
+                    </c:forEach>
+                </cache:cache>
+            </div>
+            <!-- END 'latest blog entries' column -->
+
         </div>
         <!-- END left column (main content) -->
         

--- a/src/main/webapp/projects/whack/index.jsp
+++ b/src/main/webapp/projects/whack/index.jsp
@@ -1,8 +1,20 @@
-<%@ page import="org.jivesoftware.site.Versions" %>
-
+<%@ page import="org.jivesoftware.site.Versions"%>
+<%@ page import="org.jivesoftware.webservices.RestClient"%>
+<%@ page import="org.jivesoftware.site.FeedManager"%>
 <%@ taglib uri="http://www.opensymphony.com/oscache" prefix="cache" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/xml" prefix="x" %>
+<%@ taglib uri="http://igniterealtime.org/website/tags" prefix="ir" %>
+<%
+    String baseUrl = config.getServletContext().getInitParameter("discourse_baseurl");
+    if ( baseUrl == null || baseUrl.isEmpty() )
+    {
+        baseUrl = "https://discourse.igniterealtime.org/";
+    }
+
+    request.setAttribute( "baseUrl", baseUrl );
+    request.setAttribute( "feedManager", FeedManager.getInstance() );
+    request.setAttribute( "restClient", new RestClient() );
+%>
 <html>
 <head>
 <title>Whack API</title>
@@ -86,8 +98,26 @@
                 </div>
             </div>
             <!-- END small panel -->
-            
-            
+
+            <!-- BEGIN 'latest blog entries' column -->
+            <div id="ignite_home_body_leftcol">
+                <!-- BEGIN blog header -->
+                <div id="ignite_blog_header">
+                    <span id="ignite_blog_header_label">
+                        Latest <a href="${baseUrl}/tags/c/blogs/ignite-realtime-blogs/5/whack">Blog</a> Entries
+                    </span>
+                </div>
+                <!-- END blog header -->
+
+                <%-- Show blog feed --%>
+                <cache:cache time="600" key="${baseUrl.concat('/tags/c/blogs/ignite-realtime-blogs/5/whack')}">
+                    <c:forEach items="${feedManager.getTaggedItems( baseUrl, '/c/blogs/ignite-realtime-blogs.rss', 'whack', 5 )}" var="item" varStatus="status">
+                        <ir:blogpost item="${item}" isOdd="${status.count % 2 != 0}"/>
+                    </c:forEach>
+                </cache:cache>
+            </div>
+            <!-- END 'latest blog entries' column -->
+
         </div>
         <!-- END left column (main content) -->
         


### PR DESCRIPTION
This restores the latest blog items being displayed on each project page. Blogs are taken based on the tags applies to the "ignite realtime blogs" category of Discourse.

As Discourse's RSS feed does not go back very far, and doesn't seem to offer an RSS feed for the combination of 'category' and 'tag', the amount of history that is displayed is limited.

Smack project example:

![image](https://github.com/igniterealtime/IgniteRealtime-Website/assets/4253898/cb36e8f8-3591-4fb6-8f93-ecc7c19658f8)
