### PR TITLE
Replace Apache HTTP Client 4.5 with 5.3 (and introduce caching)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,15 +278,28 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.14</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.3.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5-cache</artifactId>
+            <version>5.3.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.15.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/jivesoftware/webservices/RestClient.java
+++ b/src/main/java/org/jivesoftware/webservices/RestClient.java
@@ -1,10 +1,11 @@
 package org.jivesoftware.webservices;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpMethod;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.hc.client5.http.impl.cache.CacheConfig;
+import org.apache.hc.client5.http.impl.cache.CachingHttpClients;
+import org.apache.hc.client5.http.impl.classic.*;
+import org.apache.hc.core5.http.*;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -16,37 +17,26 @@ public class RestClient {
 
     private static final Logger Log = LoggerFactory.getLogger( RestClient.class );
 
+    private static final CacheConfig cacheConfig = CacheConfig.DEFAULT;
+
     public JSONObject get(String url) {
         JSONObject result = null;
 
-        HttpClient client = new HttpClient();
-        HttpMethod method = new GetMethod(url);
-
-        try
+        try (final CloseableHttpClient httpclient = CachingHttpClients.custom().setCacheConfig(cacheConfig).build())
         {
-            // Execute the method.
-            int statusCode = client.executeMethod( method );
-
-            if ( statusCode != HttpStatus.SC_OK )
-            {
-                Log.warn( "Method (for '{}') failed: {}", url, method.getStatusLine() );
-            }
-
-            // Deal with the response.
-            // Use caution: ensure correct character encoding and is not binary data
-            String response = method.getResponseBodyAsString();
-            result = new JSONObject(response);
-        } catch (JSONException e ) {
-            Log.warn( "Invalid content while querying '{}'", url, e );
-        } catch (HttpException e) {
-            Log.warn( "Fatal protocol violation while querying '{}'", url, e );
+            final ClassicHttpRequest httpGet = ClassicRequestBuilder.get(url).build();
+            result = httpclient.execute(httpGet, response -> {
+                try {
+                    return new JSONObject(EntityUtils.toString(response.getEntity()));
+                } catch (JSONException e) {
+                    Log.warn("Invalid content while querying '{}'", url, e);
+                    return null;
+                }
+            });
         } catch (IOException e) {
-            Log.warn( "Fatal transport error while querying '{}'", url, e );
-        } finally {
-            method.releaseConnection();
+            Log.warn("Fatal transport error while querying '{}'", url, e);
         }
 
         return result;
     }
-
 }


### PR DESCRIPTION
This updates the HTTP client used in our 'rest client'. The new client is configured to use client-sided caching, which hopefully reduces the amount of queries that are performed.