### PR TITLE
Align with look of Discourse

### DIFF
--- a/src/main/webapp/styles/global.css
+++ b/src/main/webapp/styles/global.css
@@ -61,7 +61,7 @@ hr {
 
 /* IGNITE wrapper */
 #ignite_wrapper {
-    width: 960px;
+    max-width: 1110px;
     margin: 0 auto 0 auto;
     padding: 0 5px;
     text-align: left;
@@ -84,12 +84,28 @@ hr {
 /* IGNITE header elements, including logo and navigation */
 #ignite_header {
     width: 100%;
-    background: #fff url(../images/ignite_hdr-bg.gif) top repeat-x;
-    float: left;
-    clear: both;
+    background: url(../images/ignite_nav-bg.gif) repeat-x scroll 0px 100% #000;
     padding: 0;
     margin: 0;
+    height: 136px;
     }
+
+#ignite_header::after {
+    clear: both;
+    content: '';
+    display: block;
+    overflow: hidden;
+    visibility: hidden;
+}
+
+#ignite_header_contents {
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    max-width: 1110.0px;
+    min-width: 960.0px;
+    margin: auto;
+}
+
 #ignite_logo {
     width: 225px;
     height: 85px;
@@ -210,18 +226,13 @@ hr {
     }
 
 #ignite_nav {
-    height: 41px;
+    height: 42px;
     clear: both;
     margin: 0 0 0 0;
     padding: 0;
-    border-top: 1px solid white;
     box-shadow: 0 3px 3px #DDD;
     background-color: #FDC711; /* Old browsers */
-    background: -moz-linear-gradient(top, #FDC711, #F26522); /* Firefox 3.6-15 */
-    background: -o-linear-gradient(top, #FDC711, #F26522); /* For Opera 11.1 to 12.0 */
-    background: -webkit-linear-gradient(top, #FDC711, #F26522); /* Opera 11.1-12,Chrome10-25,Safari5.1-6 */
-    background: linear-gradient(to bottom, #FDC711, #F26522); /* W3C, IE10+, Firefox16+, Chrome26+, Opera12+, Safari7+ */
-    filter: progid: DXImageTransform.Microsoft.gradient( startColorstr='#FDC711', endColorstr='#F26522', GradientType=0); /* IE6-9 */
+    background: linear-gradient(to bottom, #FDC711, #F26522);
 }
 
 #ignite_nav_groupchat {
@@ -279,11 +290,7 @@ hr {
 #ignite_nav ol li a.ignite_nav_current, 
 #ignite_nav ol li a:hover.ignite_nav_current {
     background-color: #FDC711; /* Old browsers */
-    background: -moz-linear-gradient(top, #FDC711, #F26522); /* Firefox 3.6-15 */
-    background: -o-linear-gradient(top, #FDC711, #F26522); /* For Opera 11.1 to 12.0 */
-    background: -webkit-linear-gradient(top, #FDC711, #F26522); /* Opera 11.1-12,Chrome10-25,Safari5.1-6 */
-    background: linear-gradient(to bottom, #FDC711, #F26522); /* W3C, IE10+, Firefox16+, Chrome26+, Opera12+, Safari7+ */
-    filter: progid: DXImageTransform.Microsoft.gradient( startColorstr='#FDC711', endColorstr='#F26522', GradientType=0); /* IE6-9 */
+    background: linear-gradient(to bottom, #FDC711, #F26522);
     font-weight: bold;
     }
 /* set current page nav, define first id in body tag of each section */
@@ -296,11 +303,7 @@ hr {
 #support #nav07 a, 
 #about #nav08 a {
     background-color: #FDC711; /* Old browsers */
-    background: -moz-linear-gradient(top, #FDC711, #F26522); /* Firefox 3.6-15 */
-    background: -o-linear-gradient(top, #FDC711, #F26522); /* For Opera 11.1 to 12.0 */
-    background: -webkit-linear-gradient(top, #FDC711, #F26522); /* Opera 11.1-12,Chrome10-25,Safari5.1-6 */
-    background: linear-gradient(to bottom, #FDC711, #F26522); /* W3C, IE10+, Firefox16+, Chrome26+, Opera12+, Safari7+ */
-    filter: progid: DXImageTransform.Microsoft.gradient( startColorstr='#FDC711', endColorstr='#F26522', GradientType=0); /* IE6-9 */
+    background: linear-gradient(to bottom, #FDC711, #F26522);
     font-weight: bold;
     text-decoration: none;
     }
@@ -337,7 +340,7 @@ hr {
     float: left;
     }
 #ignite_body_leftcol {
-    width: 720px;
+    max-width: 870px;
     float: left;
     }
 #ignite_body_rightcol {
@@ -443,22 +446,11 @@ hr {
 
     /*background: transparent url(../images/ignite_blog_icon_comment1.gif) no-repeat left;*/
     background-color: #FDB711; /* Old browsers */
-    background: url(../images/ignite_blog_icon_comment_15x15_lighter.gif) 5px 6px no-repeat
-    background: url(../images/ignite_blog_icon_comment_15x15_lighter.gif) 5px 6px no-repeat, -moz-linear-gradient(top, #FDB711, #F26522); /* Firefox 3.6-15 */
-    background: url(../images/ignite_blog_icon_comment_15x15_lighter.gif) 5px 6px no-repeat, -o-linear-gradient(top, #FDB711, #F26522); /* For Opera 11.1 to 12.0 */
-    background: url(../images/ignite_blog_icon_comment_15x15_lighter.gif) 5px 6px no-repeat, -webkit-linear-gradient(top, #FDB711, #F26522); /* Opera 11.1-12,Chrome10-25,Safari5.1-6 */
-    background: url(../images/ignite_blog_icon_comment_15x15_lighter.gif) 5px 6px no-repeat, linear-gradient(to bottom, #FDB711, #F26522); /* W3C, IE10+, Firefox16+, Chrome26+, Opera12+, Safari7+ */
-    filter: progid: DXImageTransform.Microsoft.gradient( startColorstr='#FDB711', endColorstr='#F26522', GradientType=0); /* IE6-9 */
-
-}
+    background: url(../images/ignite_blog_icon_comment_15x15_lighter.gif) 5px 6px no-repeat, linear-gradient(to bottom, #FDB711, #F26522);
+        }
 .ignite_blog_entry_comments a:hover {
     background-color: #FDB711; /* Old browsers */
-    background: url(../images/ignite_blog_icon_comment_15x15.gif) 5px 6px no-repeat
-    background: url(../images/ignite_blog_icon_comment_15x15.gif) 5px 6px no-repeat, -moz-linear-gradient(top, #FDB711, #F26522); /* Firefox 3.6-15 */
-    background: url(../images/ignite_blog_icon_comment_15x15.gif) 5px 6px no-repeat, -o-linear-gradient(top, #FDB711, #F26522); /* For Opera 11.1 to 12.0 */
-    background: url(../images/ignite_blog_icon_comment_15x15.gif) 5px 6px no-repeat, -webkit-linear-gradient(top, #FDB711, #F26522); /* Opera 11.1-12,Chrome10-25,Safari5.1-6 */
-    background: url(../images/ignite_blog_icon_comment_15x15.gif) 5px 6px no-repeat, linear-gradient(to bottom, #FDB711, #F26522); /* W3C, IE10+, Firefox16+, Chrome26+, Opera12+, Safari7+ */
-    filter: progid: DXImageTransform.Microsoft.gradient( startColorstr='#FDB711', endColorstr='#F26522', GradientType=0); /* IE6-9 */
+    background: url(../images/ignite_blog_icon_comment_15x15.gif) 5px 6px no-repeat, linear-gradient(to bottom, #FDB711, #F26522);
         }
 .ignite_blog_entry h2 {
     font-family: Georgia, "Times New Roman", Times, serif;
@@ -1238,16 +1230,7 @@ div.ignite_sidebar_body_chat {
 .sidebar_grad {
     /* Old browsers */
     background: #878787;
-    /* Firefox 3.6-15 */
-    background: -moz-linear-gradient(top, #878787, #383838);
-    /* For Opera 11.1 to 12.0 */
-    background: -o-linear-gradient(top, #878787, #383838);
-    /* Opera 11.1-12,Chrome10-25,Safari5.1-6 */
-    background: -webkit-linear-gradient(top, #878787, #383838);
-    /* W3C, IE10+, Firefox16+, Chrome26+, Opera12+, Safari7+ */
     background: linear-gradient(to bottom, #878787, #383838);
-    /* IE6-9 */
-    filter: progid: DXImageTransform.Microsoft.gradient( startColorstr='#878787', endColorstr='#383838', GradientType=0);
 }
 
 /* End of sidebar form and shapes, begin of sidebar content. */

--- a/src/main/webapp/styles/home.css
+++ b/src/main/webapp/styles/home.css
@@ -106,7 +106,6 @@ styles specific to the home page for the Ignite Real Time site.
 
 #ignite_home_body {
     float: left;
-    width: 720px;
     }
 #ignite_home_body_leftcol {
     width: 100%;

--- a/src/main/webapp/template/default.jsp
+++ b/src/main/webapp/template/default.jsp
@@ -52,14 +52,11 @@
 
 
 
-<!-- BEGIN page 'wrapper' -->
-<div id="ignite_wrapper">
-                                                              
-
-    <!-- BEGIN header -->
-    <div id="ignite_header">
+<!-- BEGIN header -->
+<div id="ignite_header">
+    <div class="clearfix" id="ignite_header_contents">
         <a href="/"><div id="ignite_logo"></div></a>
-        <div id="ignite_nav">
+        <div class="clearfix" id="ignite_nav">
             <ol>
                 <li id="nav01"><a href="<%= request.getContextPath() %>/">Home</a></li>
                 <li id="nav02"><a href="<%= request.getContextPath() %>/projects/">Projects</a></li>
@@ -69,23 +66,26 @@
                 <li id="nav07"><a href="<%= request.getContextPath() %>/support/">Support</a></li>
                 <li id="nav08"><a href="<%= request.getContextPath() %>/about/">About</a></li>
             </ol>
-        <!--    <div id="ignite_nav_groupchat" class="ignite_nav_groupchat" style="display: none;">
+            <!--    <div id="ignite_nav_groupchat" class="ignite_nav_groupchat" style="display: none;">
                 <span class="ignite_nav_groupchat_block" id="ignite_nav_groupchat_block"></span>
                 <span id="ignite_nav_groupchat_moreinfo" style="display: none;"><a href="<%= request.getContextPath() %>/support/group_chat.jsp">More Information</a></span>
             </div> -->
         </div>
     </div>
-    <!-- END header -->
+</div>
+<!-- END header -->
     <!-- <script type="text/javascript">
     // The javascript timer for the header group chat callout
     runGroupChatTimer();
     </script> -->
 
+<!-- BEGIN page 'wrapper' -->
+<div id="ignite_wrapper">
 
 
     <decorator:body />
 
-    
+
     <!-- BEGIN footer -->
     <div id="ignite_footer">
         <div class="ignite_footer_nav"><a href="<%= request.getContextPath() %>/">Home</a> | <a href="<%= request.getContextPath() %>/projects/">Projects</a> | <a href="<%= request.getContextPath() %>/downloads/">Downloads</a> | <a href="https://discourse.igniterealtime.org/">Community</a> | <a href="<%= request.getContextPath() %>/fans/">Fans</a> | <a href="<%= request.getContextPath() %>/support/">Support</a> | <a href="<%= request.getContextPath() %>/about/">About</a> </div>


### PR DESCRIPTION
This makes the website a tad wider (just as wide as the main content of Discourse) and aligns the header with that of Discourse.

I'm far from a webdesigner, so I'd welcome feedback.

The idea behind this change is to both:
- make our website and discourse integrate better
- have more room in our website, to re-arrange content (in a later stage)

![image](https://github.com/user-attachments/assets/0cb3ad50-693c-4029-8a1b-0fefed4078e1)
