### PR TITLE
Add DBCP as a dependency (should fix database connection)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@
             <artifactId>mysql-connector-j</artifactId>
             <version>8.3.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <version>2.12.0</version>
+        </dependency>
 
         <dependency>
             <groupId>rome</groupId>


### PR DESCRIPTION
After updating Tomcat, I noticed that downloads were no longer being recorded in the database. I suspect that this is caused by the upgrade having removed the DBCP (database connection pool) library. This was found in logging when Tomcat was starting up:

```
[main] org.apache.catalina.core.NamingContextListener.addResource Failed to register in JMX: [javax.naming.NamingException: Could not load resource factory class [Root exception is java.lang.ClassNotFoundException: org.apache.commons.dbcp.BasicDataSourceFactory]]
```

Instead of adding the library to Tomcat, it is being bundled in this (root) application, which hopefully works well enough (and no longer depends on us having a specific Tomcat configuration when upgrading). The database driver is already being included in the same way, after all.