### PR TITLE
Logging: make SLF4J record to JCL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,8 +229,14 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
+            <artifactId>slf4j-jcl</artifactId>
             <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.3.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
Tomcat uses Java Commons Logging. With this change, SLF4J (used by our application) should hook into that.

This intends to make the logs generated by our app visible in Tomcat's logs.