### PR TITLE
Reduce errors while processing plugins

### DIFF
--- a/src/main/java/org/jivesoftware/site/DownloadStats.java
+++ b/src/main/java/org/jivesoftware/site/DownloadStats.java
@@ -279,6 +279,10 @@ public class DownloadStats extends HttpServlet {
      */
     public static void addListingToDatabase( String ipAddress, String product, String os, int type, ServletContext context )
     {
+        // Correct for X-Forwarded-For header value sometimes containing a list of IPs. Use the last one.
+        if (ipAddress != null && ipAddress.contains(",")) {
+            ipAddress = ipAddress.substring(ipAddress.indexOf(",")+1).trim();
+        }
         final DbConnectionManager connectionManager = DbConnectionManager.getInstance();
         Connection con = null;
         PreparedStatement pstmt = null;

--- a/src/main/java/org/jivesoftware/site/PluginDownloadServlet.java
+++ b/src/main/java/org/jivesoftware/site/PluginDownloadServlet.java
@@ -299,6 +299,10 @@ public class PluginDownloadServlet extends HttpServlet {
     {
         try ( final InputStream in = getUncompressedEntryFromArchive( archive, "plugin.xml" ) )
         {
+            if (in == null) {
+                Log.info("Unable to find 'plugin.xml' in '{}", archive);
+                return null;
+            }
             final SAXReader saxReader = new SAXReader();
             final Document doc = saxReader.read(in);
             final Element element = (Element)doc.selectSingleNode( propertyPath );

--- a/src/main/java/org/jivesoftware/site/PluginManager.java
+++ b/src/main/java/org/jivesoftware/site/PluginManager.java
@@ -35,6 +35,8 @@ import org.jivesoftware.util.PluginVersionComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.jivesoftware.site.PluginDownloadServlet.getUncompressedEntryFromArchive;
+
 public class PluginManager
 {
     private static final Logger Log = LoggerFactory.getLogger( PluginManager.class );
@@ -382,6 +384,10 @@ public class PluginManager
             this.mavenFile = mavenFile;
             try ( final JarFile archive = new JarFile( mavenFile.toFile() ) )
             {
+                if (getUncompressedEntryFromArchive(archive, "plugin.xml") == null) {
+                    throw new IOException("Unable to find 'plugin.xml' in: " + mavenFile);
+                }
+
                 this.hasReadme = PluginDownloadServlet.archiveContainsEntry( archive, "readme.html");
                 this.hasChangelog = PluginDownloadServlet.archiveContainsEntry( archive, "changelog.html");
 


### PR DESCRIPTION
When a plugin jar file is invalid, the amount of errors logged should be dramatically reduced.