### PR TITLE
Fix missing date for Openfire plugins

### DIFF
--- a/src/main/webapp/projects/openfire/plugin-archive.jsp
+++ b/src/main/webapp/projects/openfire/plugin-archive.jsp
@@ -6,11 +6,8 @@
         return;
     }
 %>
-<%@ page import="java.net.URLEncoder"%>
-<%@ page import="java.nio.charset.StandardCharsets"%>
 <%@ page import="java.nio.file.Path"%>
 <%@ page import="java.nio.file.Paths"%>
-<%@ page import="java.text.DateFormat"%>
 <%@ page import="java.util.List"%>
 <%@ page import="org.jivesoftware.site.PluginManager" %>
 <%@ page import="java.io.BufferedReader" %>
@@ -22,6 +19,7 @@
 <%@ page import="org.jsoup.safety.Safelist" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://igniterealtime.org/website/tags" prefix="ir" %>
 <%
     String openfirePluginsPath = config.getServletContext().getInitParameter("openfire-plugins-path");


### PR DESCRIPTION
The Openfire plugins archive page lists all versions for a certain plugin. The 'release date' column is empty (but should not be). That is fixed by this commit.

The similar column on the page that lists all different plugins didn't suffer from this problem.

Prior to this commit:

![image](https://github.com/user-attachments/assets/7854f8a0-b064-4a9c-8dab-48bf89bf1ab1)

After this commit:

![image](https://github.com/user-attachments/assets/186d5385-0850-461b-9a58-62b73934dd7a)
