### PR TITLE
WEB-82: Restore listing of chatroom JID

### DIFF
--- a/src/main/webapp/support/group_chat.jsp
+++ b/src/main/webapp/support/group_chat.jsp
@@ -34,11 +34,7 @@
 
         <iframe src="converse.jsp" style="width:100%;height:574px;"></iframe>
 
-        <!-- <p>Alternatively, you may use any <a href="https://xmpp.org/software/clients.html">XMPP client</a>
-        to connect to the group chat service at conference.igniterealtime.org. The chat name is
-        &quot;Open Chat&quot; and its address is open_chat@conference.igniterealtime.org.</p> -->
-
-        <p>The web-based group chat client used is <a href="https://conversejs.org/">ConverseJS</a>.</p>
+        <p>The web-based group chat client used is <a href="https://conversejs.org/">ConverseJS</a>. Alternatively, you can join with your own client, using the chat room address <a href="xmpp:open_chat@conference.igniterealtime.org?join">open_chat@conference.igniterealtime.org</a></p>
 
     </main>
 


### PR DESCRIPTION
Under WEB-82, the text explaining how to join the chat room with an XMPP client was removed, to conserve screem real-estate.

It is desirable to have at least the address be listed. As XMPP now supports URIs, we can easily provide a very short sentence with a link in it, that is usable by people that have installed an XMPP client. In this commit, that's placed on the same line as the 'powered by Converse' line, to minimize the space that this extra text takes up.