### PR TITLE
Add explicit CC BY-SA 4.0 license statement to fans page

### DIFF
--- a/src/main/webapp/fans/index.jsp
+++ b/src/main/webapp/fans/index.jsp
@@ -23,6 +23,12 @@
                     buttons, and logos. To add the screenshots or buttons, simply copy and paste the code
                     below the image into your site or blog.
                 </p>
+                <p>
+                    <strong>License</strong>: The logos, buttons, and screenshots on this page are made available by the
+                    Ignite Realtime Foundation under the Creative Commons Attribution-ShareAlike 4.0 International license
+                    (CC BY-SA 4.0). The Ignite Realtime name and logo are also trademarks of the Foundation; the license
+                    covers copyright, not trademark rights.
+                </p>
             </div>
 
             <div class="ignite_fans_block">


### PR DESCRIPTION
The fans page offers logos, buttons, and screenshots for reuse but never stated the terms. This left the copyright status ambiguous for downstream reusers (including Wikimedia Commons, which flagged an upload of our logo for deletion because implicit "here, take this" permission is not a license).

Declare the assets CC BY-SA 4.0 and note that trademark rights in the Ignite Realtime name and logo are unaffected by the copyright license.

I'm not particularly invested in the _specific_ license used. I used a common one. Happy to switch to another if that's preferable.